### PR TITLE
Fixes route to adapt for `main.js` relative URL.

### DIFF
--- a/now.json
+++ b/now.json
@@ -142,6 +142,11 @@
   ],
   "routes": [
     {
+      "src": "/packages/([^/]+)$",
+      "status": 301,
+      "headers": { "Location": "/packages/$1/" }
+    },
+    {
       "src": "/01-setup/main.js",
       "dest": "/packages/01-setup/main.js"
     },


### PR DESCRIPTION
This PR makes sure we are loading `index.html` with a trailing slash. Check #12 for details.